### PR TITLE
Allow api key to be set via model.key

### DIFF
--- a/llm_mistral.py
+++ b/llm_mistral.py
@@ -81,7 +81,7 @@ class Mistral(llm.Model):
         return messages
 
     def execute(self, prompt, stream, response, conversation):
-        key = llm.get_key("", "mistral", "LLM_MISTRAL_KEY")
+        key = llm.get_key("", "mistral", "LLM_MISTRAL_KEY") or getattr(self, "key", None)
         messages = self.build_messages(prompt, conversation)
         response._prompt_json = {"messages": messages}
         body = {


### PR DESCRIPTION
This makes the behavior consistent with the openai's one documented in https://llm.datasette.io/en/stable/python-api.html#basic-prompt-execution