### PR TITLE
Add an alias for mistral-nemo

### DIFF
--- a/llm_mistral.py
+++ b/llm_mistral.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 DEFAULT_ALIASES = {
     "mistral/mistral-tiny": "mistral-tiny",
+    "mistral/open-mistral-nemo": "mistral-nemo",
     "mistral/mistral-small": "mistral-small",
     "mistral/mistral-medium": "mistral-medium",
     "mistral/mistral-large-latest": "mistral-large",


### PR DESCRIPTION
The Mistral NeMo model [was unveiled today](https://mistral.ai/news/mistral-nemo/). It is open-source and available through their API.