### PR TITLE
Return llm.ModelError instead of click error

### DIFF
--- a/llm_mistral.py
+++ b/llm_mistral.py
@@ -311,7 +311,7 @@ class Mistral(_Shared, llm.KeyModel):
                         # Try to make this a readable error, it may have a base64 chunk
                         try:
                             decoded = json.loads(event_source.response.read())
-                            type = decoded["type"]
+                            type = decoded.get("type", "UnknownType")
                             words = decoded["message"].split()
                         except (json.JSONDecodeError, KeyError):
                             click.echo(
@@ -383,7 +383,7 @@ class AsyncMistral(_Shared, llm.AsyncKeyModel):
                         # Try to make this a readable error, it may have a base64 chunk
                         try:
                             decoded = json.loads(await event_source.response.aread())
-                            type = decoded["type"]
+                            type = decoded.get("type", "UnknownType")
                             words = decoded["message"].split()
                         except (json.JSONDecodeError, KeyError):
                             click.echo(

--- a/llm_mistral.py
+++ b/llm_mistral.py
@@ -321,7 +321,7 @@ class Mistral(_Shared, llm.KeyModel):
                         # Truncate any words longer than 30 characters
                         words = [word[:30] for word in words]
                         message = " ".join(words)
-                        raise click.ClickException(
+                        raise llm.ModelError(
                             f"{event_source.response.status_code}: {type} - {message}"
                         )
                     usage = None
@@ -394,7 +394,7 @@ class AsyncMistral(_Shared, llm.AsyncKeyModel):
                         # Truncate any words longer than 30 characters
                         words = [word[:30] for word in words]
                         message = " ".join(words)
-                        raise click.ClickException(
+                        raise llm.ModelError(
                             f"{event_source.response.status_code}: {type} - {message}"
                         )
                     event_source.response.raise_for_status()


### PR DESCRIPTION
Hi, 

It seems that the other llm-XXX (e.g. llm-gemini) return llm.ModelError when the API returns something else than status code 200. 

This PR replace the click error that was thrown by said llm.ModelError. 
I also handled the case when the mistral API does not return a type field in the error dict.

Cheers,
Augustin