### PR TITLE
build: add explicit setuptools build system configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "llm-mistral"
 version = "0.15"


### PR DESCRIPTION
## Problem

Without a `[build-system]` section, `uv` treats the project as virtual and only installs dependencies—it does NOT build or install the project itself. Thus `uv run --extra test pytest` fails:
```
FAILED tests/test_mistral.py::test_caches_models - AssertionError: assert False
FAILED tests/test_mistral.py::test_stream - llm.UnknownModelError: 'Unknown model: mistral-tiny'
FAILED tests/test_mistral.py::test_stream_async - llm.UnknownModelError: 'Unknown model: mistral-tiny'
FAILED tests/test_mistral.py::test_async_no_stream - llm.UnknownModelError: 'Unknown model: mistral-tiny'
FAILED tests/test_mistral.py::test_stream_with_options - llm.UnknownModelError: 'Unknown model: mistral-tiny'
FAILED tests/test_mistral.py::test_no_stream - llm.UnknownModelError: 'Unknown model: mistral-tiny'
FAILED tests/test_mistral.py::test_tools_stream - llm.UnknownModelError: 'Unknown model: mistral/mistral-medium'
ERROR tests/test_mistral.py::test_caches_models - AssertionError: The following responses are mocked but not requested:
ERROR tests/test_mistral.py::test_stream - AssertionError: The following responses are mocked but not requested:
ERROR tests/test_mistral.py::test_stream_async - AssertionError: The following responses are mocked but not requested:
ERROR tests/test_mistral.py::test_async_no_stream - AssertionError: The following responses are mocked but not requested:
ERROR tests/test_mistral.py::test_stream_with_options - AssertionError: The following responses are mocked but not requested:
ERROR tests/test_mistral.py::test_no_stream - AssertionError: The following responses are mocked but not requested:
ERROR tests/test_mistral.py::test_tools_stream - AssertionError: The following responses are mocked but not requested:
```

The reason is the missing entry point registration:
1. No `[build-system]` → uv doesn't install the project
2. Project not installed → entry points not registered
3. Entry points not registered → llm can't discover the Mistral models plugin
4. Plugin not discovered → `llm.get_model("mistral-tiny")` fails

This is why `uv run --extra test pytest` failed, but `pip install -e '.[test]'` worked—pip always builds and installs packages, while uv requires an explicit build-system declaration.

## Solution

Add `[build-system]` with setuptools to tell uv to build and install the project, which registers the entry points and allows the llm system to discover the plugin and its models.

Use setuptools to align with the llm ecosystem standard:
- **llm** (main package) uses setuptools
- **llm-openai-plugin** uses setuptools

## Testing

All 7 tests pass successfully:
```
tests/test_mistral.py .......                                            [100%]
============================== 7 passed in 0.54s ===============================
```

🤖 Human checked and modified, based on a PR generated with [Claude Code](https://claude.com/claude-code)